### PR TITLE
Selfie Cleanup

### DIFF
--- a/vision_app/app/build.gradle
+++ b/vision_app/app/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1' //Updated November 2017
     }
 }
 

--- a/vision_app/app/src/main/AndroidManifest.xml
+++ b/vision_app/app/src/main/AndroidManifest.xml
@@ -32,10 +32,6 @@
             </intent-filter>
         </activity>
 
-        <activity android:name=".SelfieActivity"
-            android:screenOrientation="landscape"
-            android:configChanges="keyboardHidden|orientation" />
-
         <receiver
             android:name=".ChezyDeviceAdminReceiver"
             android:description="@string/device_admin_description"

--- a/vision_app/app/src/main/java/com/team254/cheezdroid/Configuration.java
+++ b/vision_app/app/src/main/java/com/team254/cheezdroid/Configuration.java
@@ -25,6 +25,7 @@ public final class Configuration
 
     //Constant for the Video Connection Information
     public static final int VIDEO_PORT = 5800;
+    public static final boolean DEFAULT_SHOULD_VIDEO_STREAM = true;
 
     //WakeLock Acquiring Timeout Constant (if 0, it will Assume No Timeout [1Sec * 1000ms/sec])
     public static final int WAKE_LOCK_ACQUIRE_TIMEOUT =  1000;

--- a/vision_app/app/src/main/java/com/team254/cheezdroid/Preferences.java
+++ b/vision_app/app/src/main/java/com/team254/cheezdroid/Preferences.java
@@ -108,7 +108,7 @@ public class Preferences
         if (m_h_ranges == null)
         {
             Resources res = m_context.getResources();
-            m_h_ranges = new Pair<>(getInt(m_context.getString(R.string.threshold_h_min_key), res.getInteger(R.integer.default_h_min)), getInt(m_context.getString(R.string.threshold_h_max_key), res.getInteger(R.integer.default_h_max)));
+            m_h_ranges = new Pair<>(getInt(m_context.getString(R.string.threshold_h_max_key), res.getInteger(R.integer.default_h_max)), getInt(m_context.getString(R.string.threshold_h_min_key), res.getInteger(R.integer.default_h_min)));
         }
         return m_h_ranges;
     }
@@ -122,7 +122,7 @@ public class Preferences
         if (m_s_ranges == null)
         {
             Resources res = m_context.getResources();
-            m_s_ranges = new Pair<>(getInt(m_context.getString(R.string.threshold_s_min_key), res.getInteger(R.integer.default_s_min)), getInt(m_context.getString(R.string.threshold_s_max_key), res.getInteger(R.integer.default_s_max)));
+            m_s_ranges = new Pair<>(getInt(m_context.getString(R.string.threshold_s_max_key), res.getInteger(R.integer.default_s_max)), getInt(m_context.getString(R.string.threshold_s_min_key), res.getInteger(R.integer.default_s_min)));
         }
         return m_s_ranges;
     }
@@ -136,7 +136,7 @@ public class Preferences
         if (m_v_ranges == null)
         {
             Resources res = m_context.getResources();
-            m_v_ranges = new Pair<>(getInt(m_context.getString(R.string.threshold_v_min_key), res.getInteger(R.integer.default_v_min)), getInt(m_context.getString(R.string.threshold_v_max_key), res.getInteger(R.integer.default_v_max)));
+            m_v_ranges = new Pair<>(getInt(m_context.getString(R.string.threshold_v_max_key), res.getInteger(R.integer.default_v_max)), getInt(m_context.getString(R.string.threshold_v_min_key), res.getInteger(R.integer.default_v_min)));
         }
         return m_v_ranges;
     }

--- a/vision_app/app/src/main/java/com/team254/cheezdroid/VisionTrackerActivity.java
+++ b/vision_app/app/src/main/java/com/team254/cheezdroid/VisionTrackerActivity.java
@@ -543,7 +543,9 @@ public class VisionTrackerActivity extends Activity implements RobotConnectionSt
             public void onRangeSeekBarValuesChanged(RangeSeekBar<?> rangeSeekBar, Integer min, Integer max)
             {
                 Log.i("H", min + " " + max);
-                m_prefs.setThresholdHRange(min, max);
+                Log.d("HValue", min + " " + max);
+                //m_prefs.setThresholdHRange(min, max);
+                m_prefs.setThresholdHRange(max, min);
             }
         });
 
@@ -556,7 +558,9 @@ public class VisionTrackerActivity extends Activity implements RobotConnectionSt
             public void onRangeSeekBarValuesChanged(RangeSeekBar<?> rangeSeekBar, Integer min, Integer max)
             {
                 Log.i("S", min + " " + max);
-                m_prefs.setThresholdSRange(min, max);
+                Log.d("SValue", min + " " + max);
+                //m_prefs.setThresholdSRange(min, max);
+                m_prefs.setThresholdSRange(max, min);
             }
         });
 
@@ -569,7 +573,9 @@ public class VisionTrackerActivity extends Activity implements RobotConnectionSt
             public void onRangeSeekBarValuesChanged(RangeSeekBar<?> rangeSeekBar, Integer min, Integer max)
             {
                 Log.i("V", min + " " + max);
-                m_prefs.setThresholdVRange(min, max);
+                Log.d("VValue", min + " " + max);
+                //m_prefs.setThresholdVRange(min, max);
+                m_prefs.setThresholdVRange(max, min);
             }
         });
 

--- a/vision_app/app/src/main/jni/image_processor.cpp
+++ b/vision_app/app/src/main/jni/image_processor.cpp
@@ -158,7 +158,7 @@ std::vector<TargetInfo> processImpl(int w, int h, int texOut, DisplayMode mode,
 
             TargetInfo targetI = accepted_targets[i];
             TargetInfo targetJ = accepted_targets[j];
-            double offset = abs(targetI.centroid_x - targetJ.centroid_x);
+            double offset = std::abs(targetI.centroid_x - targetJ.centroid_x);
             if (offset < kMaxOffset)
             {
                 TargetInfo topTarget = targetI.centroid_y > targetJ.centroid_y ? targetI : targetJ;

--- a/vision_app/build.gradle
+++ b/vision_app/build.gradle
@@ -2,13 +2,15 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1' //Updated November 2017
     }
 }
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }

--- a/vision_app/openCVLibrary310/build.gradle
+++ b/vision_app/openCVLibrary310/build.gradle
@@ -5,7 +5,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'  //last version jan 2016
+        classpath 'com.android.tools.build:gradle:3.0.1'  //Updated November 2017
+
     }
 }
 


### PR DESCRIPTION
Took out the selfie activity and its related classes, because they were a bit obsolete given the constant video streams now capable in the code.  Additionally, there were several code improvements and bug fixes that were discovered in the removal of this.